### PR TITLE
Analysis while heating

### DIFF
--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -91,6 +91,7 @@ $(function() {
       self.exactDurations = printTimeGeniusSettings.exactDurations;
       self.enableOctoPrintAnalyzer = printTimeGeniusSettings.enableOctoPrintAnalyzer;
       self.allowAnalysisWhilePrinting = printTimeGeniusSettings.allowAnalysisWhilePrinting;
+      self.allowAnalysisWhileHeating = printTimeGeniusSettings.allowAnalysisWhileHeating;
       self.print_history = printTimeGeniusSettings.print_history;
       // Overwrite the formatFuzzyPrintTime as needed.
       self.originalFormatFuzzyPrintTime = formatFuzzyPrintTime;

--- a/octoprint_PrintTimeGenius/templates/PrintTimeGenius_settings.jinja2
+++ b/octoprint_PrintTimeGenius/templates/PrintTimeGenius_settings.jinja2
@@ -3,6 +3,10 @@
     <h3>{{ _('General options') }}</h3>
     <label class="checkbox"><input type="checkbox" data-bind="checked: exactDurations">{{ _('Display precise durations instead of fuzzy ones') }}</label>
     <label class="checkbox"><input type="checkbox" data-bind="checked: enableOctoPrintAnalyzer">{{ _('Enable OctoPrint\'s built-in analyzer (slow and unnecessary)') }}</label>
+    <label title="{{ _('Analyzing a file while heating should not affect performace.') }}"
+           class="checkbox"><input
+                              type="checkbox"
+                              data-bind="checked: allowAnalysisWhileHeating">{{ _('Allow analysis while heating (only takes effect after saving)') }}</label>
     <label title="{{ _('Analyzing a file while printing might cause poor printing performace.') }}"
            class="checkbox"><input
                               type="checkbox"

--- a/submodules/build_calc.sh
+++ b/submodules/build_calc.sh
@@ -6,6 +6,6 @@ pushd "${SCRIPTPATH}"
 git submodule update --remote --recursive
 popd
 pushd "${SCRIPTPATH}/Marlin/Marlin"
-scons -j 10 || true
+scons -i -j 10 || true
 cp -f */marlin-calc.* "${SCRIPTPATH}/../octoprint_PrintTimeGenius/analyzers"
 popd


### PR DESCRIPTION
This allows analyzing files in the first few minutes of heating, until the heating elements reach the target temperature.  It's done by comparing the target to the actual and allowing analysis so long as the actual is at least 5C below the target temperature for at least one heater.  That implies that there is at least one thing still waiting to get hot enough.

Heaters that are turned off are ignored.  At least one heater must be on for analysis to be cancelled.

So long as heating updates occur frequently (it's usually 1-2 seconds between updates) then we should turn off analysis in time to not affect gcode printing.

This is turned on by default, unlike analyze while printing, which is to analyze even after heating, and that is off by default.