### PR TITLE
reduce general performance impact

### DIFF
--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -74,7 +74,14 @@ $(function() {
     };
 
     self.update_filelist = function() {
-        self.FileList(self.theFiles(self.filesViewModel.allItems()));
+        let files = self.theFiles(self.filesViewModel.allItems())
+            .sort(function(a,b) {
+                if (_.has(a, "gcodeAnalysis.progress") != _.has(b, "gcodeAnalysis.progress")) {
+                    return (_.has(a, "gcodeAnalysis.progress") - _.has(b, "gcodeAnalysis.progress"));
+                }
+                return a.path.localeCompare(b.path);
+            });
+        self.FileList(files);
     };
 
     self.onEventUpdatedFiles = function(payload) {

--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -60,15 +60,15 @@ $(function() {
       }
     });
     self.printerStateViewModel.printTimeLeftOrigin.valueHasMutated();
-    
+
     self.theFiles = function(items) {
     	let results = [];
     	let queue = [{children: items}];
 
     	while (queue.length > 0) {
     		item = queue.shift();
-    		results.push.apply(results, item.children.filter(item => item["type"] == "machinecode"));
-    		queue.push.apply(queue, item.children.filter(item => "children" in item));
+    		results.push(...item.children.filter(item => item["type"] == "machinecode"));
+    		queue.push(...item.children.filter(item => "children" in item));
     	}
     	return results;
     };

--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -13,7 +13,6 @@ $(function() {
     self.filesViewModel = parameters[2];
     self.selectedGcodes = ko.observable();
     self.print_history = ko.observableArray();
-    self.FileList = ko.observableArray([]);
     self.settings_visible = ko.observable(false);
     self.version = undefined;
 
@@ -73,26 +72,22 @@ $(function() {
     	return results;
     };
 
-    self.update_filelist = function() {
-        let files = self.theFiles(self.filesViewModel.allItems())
+    self.FileList = ko.pureComputed(function() {
+        // only compute FileList when settings is visible
+        if (!self.settings_visible()) {
+            return [];
+        }
+        return self.theFiles(self.filesViewModel.allItems())
             .sort(function(a,b) {
                 if (_.has(a, "gcodeAnalysis.progress") != _.has(b, "gcodeAnalysis.progress")) {
                     return (_.has(a, "gcodeAnalysis.progress") - _.has(b, "gcodeAnalysis.progress"));
                 }
                 return a.path.localeCompare(b.path);
             });
-        self.FileList(files);
-    };
-
-    self.onEventUpdatedFiles = function(payload) {
-        if (self.settings_visible() && payload.type === 'printables') {
-            setTimeout(self.update_filelist, 20000);
-        }
-    };
+    });
 
     self.onSettingsShown = function() {
         self.settings_visible(true);
-        self.update_filelist();
     };
 
     self.onSettingsHidden = function() {

--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -70,19 +70,25 @@ $(function() {
         }
       }
       return results;
-    }
+    };
 
-    self.FileList = ko.pureComputed(function() {
-      return self.recurseFiles(self.filesViewModel.allItems()).slice()
-          .sort(function(a,b) {
-            if (_.has(a, "gcodeAnalysis.progress") !=
-                _.has(b, "gcodeAnalysis.progress")) {
-              return (_.has(a, "gcodeAnalysis.progress") -
-                      _.has(b, "gcodeAnalysis.progress"));
-            }
-            return a.path.localeCompare(b.path);
-          });
-    });
+    self.theFiles = function(items) {
+    	let results = [];
+    	let queue = [{children: items}];
+
+    	while (queue.length > 0) {
+    		item = queue.shift();
+    		results.push.apply(results, item.children.filter(item => item["type"] == "machinecode"));
+    		queue.push.apply(queue, item.children.filter(item => "children" in item));
+    	}
+    	return results;
+    };
+
+    self.FileList = ko.observableArray([]);
+
+    self.onSettingsShown = function() {
+        self.FileList(self.theFiles(self.filesViewModel.allItems()));
+    }
 
     self.analyzeCurrentFile = function () {
       let items = self.selectedGcodes();

--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -60,20 +60,7 @@ $(function() {
       }
     });
     self.printerStateViewModel.printTimeLeftOrigin.valueHasMutated();
-
-    self.recurseFiles = function(items) {
-      let results = [];
-      for (let item of items) {
-        if (item["type"] == "machinecode") {
-          results.push(item);
-        }
-        if ("children" in item) {
-          results = results.concat(self.recurseFiles(item.children));
-        }
-      }
-      return results;
-    };
-
+    
     self.theFiles = function(items) {
     	let results = [];
     	let queue = [{children: items}];

--- a/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
+++ b/octoprint_PrintTimeGenius/static/js/PrintTimeGenius.js
@@ -13,6 +13,8 @@ $(function() {
     self.filesViewModel = parameters[2];
     self.selectedGcodes = ko.observable();
     self.print_history = ko.observableArray();
+    self.FileList = ko.observableArray([]);
+    self.settings_visible = ko.observable(false);
     self.version = undefined;
 
     // Overwrite the printTimeLeftOriginString function
@@ -84,11 +86,24 @@ $(function() {
     	return results;
     };
 
-    self.FileList = ko.observableArray([]);
+    self.update_filelist = function() {
+        self.FileList(self.theFiles(self.filesViewModel.allItems()));
+    };
+
+    self.onEventUpdatedFiles = function(payload) {
+        if (self.settings_visible() && payload.type === 'printables') {
+            setTimeout(self.update_filelist, 20000);
+        }
+    };
 
     self.onSettingsShown = function() {
-        self.FileList(self.theFiles(self.filesViewModel.allItems()));
-    }
+        self.settings_visible(true);
+        self.update_filelist();
+    };
+
+    self.onSettingsHidden = function() {
+        self.settings_visible(false);
+    };
 
     self.analyzeCurrentFile = function () {
       let items = self.selectedGcodes();


### PR DESCRIPTION
two things here:
- don't populate self.FileList every page load; it's only needed if we're in the settings page
- implement an iterative file scan to avoid recursion

I've been using this patch for some time now on my local install and it really helps if you keep many gcode files on your OctoPrint box