### PR TITLE
deprecation fix

### DIFF
--- a/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
@@ -7,9 +7,9 @@ import sys
 from collections import defaultdict
 import argparse
 if float('.'.join((str(sys.version_info.major), str(sys.version_info.minor)))) < 3.3:
-  from collections import Mapping as collections_mapping
+  from collections import Mapping as collections_Mapping
 else:
-  from collections.abc import Mapping as collections_mapping
+  from collections.abc import Mapping as collections_Mapping
 
 dd = lambda: defaultdict(dd)
 

--- a/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
@@ -5,8 +5,11 @@ import re
 import json
 import sys
 from collections import defaultdict
-import collections
 import argparse
+if float('.'.join((str(sys.version_info.major), str(sys.version_info.minor)))) < 3.3:
+  from collections import Mapping as collections_mapping
+else:
+  from collections.abc import Mapping as collections_mapping
 
 dd = lambda: defaultdict(dd)
 
@@ -172,7 +175,7 @@ first_filament_filepos = None
 def update(d, u):
   """Do deep updates of dict."""
   for k, v in u.items():
-    if isinstance(v, collections.Mapping):
+    if isinstance(v, collections_Mapping):
       d[k] = update(d.get(k, dd()), v)
     else:
       d[k] = v


### PR DESCRIPTION
There is no issue associated with this PR. When investigating the deprecation in the log, I saw it was an 'easy' fix and figured I'd just write a patch to fix it directly.

[In Python 3.3](https://bugs.python.org/issue11085) some changes to the collections module was made and support for the previous organization of the module was maintained for 2.7 compatibility. 2.7 is now well beyond EOL and this backwards compatibility is scheduled to be removed - Python 3.9 is to be the *last* version supporting this. While they have been moving the goalpost later and later, eventually this will stop and it will cause breakage.

This is exposed by the following output in the plugin's log:

    Sarge output: /opt/octoprint/lib/python3.8/site-packages/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py:175: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working

This PR fixes the deprecation warning by testing the interpreter version and if earlier than 3.3 imports `collections.Mapping`. If 3.3 or later, it instead imports `collections.abc.Mapping`. In both cases it binds it to a local name and the reference to `collections.Mapping` in the code has been changed to use this local name instead.

PLEASE NOTE: I do not have an installed python interpreter other than 3.8x so I cannot test the "old version" case personally, but I can confirm it works flawlessly on 3.8. Given the simple nature of the logic I can't see why it would fail to work in the other case.