### PR TITLE
Get rid of unnecessary logging dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ plugin_license = "AGPLv3"
 # Any additional requirements besides OctoPrint should be listed here
 # For now, require the working release, which is only 1.3.9rc1.
 plugin_requires = ["OctoPrint>=1.3.9rc1", "psutil", "sarge"]
-from sys import version_info
-if version_info[0] < 3:
-    plugin_requires.append("logging")
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
`logging` has been part of Python's standard library since forever (and certainly for all versions of Python that OctoPrint will run under). There's no need to pull in a third party implementation of it that clashes with the standard library version and actually causes issues within `pip` itself.

Closes #241