### PR TITLE
Update .gitmodules repo protocol (to support general public use)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/Marlin"]
 	path = submodules/Marlin
-	url = git@github.com:eyal0/Marlin.git
+	url = https://github.com/eyal0/Marlin.git
 	branch = estimate-bugfix-2.0.x


### PR DESCRIPTION
correct your marlin fork repo URL to use https+git instead, so that folks who don't have privileges on that repo (ie, the general public) can still install this plugin via pip.

This came up when trying to recover my installation after an OS upgrade replaced my python interpreter with a new version, causing me to have to "rebuild" site-packages.

While doing so, I got a `pip freeze` output of the original site-packages which included:
`OctoPrint-PrintTimeGenius @ git+https://github.com/eyal0/OctoPrint-PrintTimeGenius.git@70081671a24628aa23d9da28ff58b7b9ec8fa104`

This fails out with the following:

    Collecting OctoPrint-PrintTimeGenius@ git+https://github.com/eyal0/OctoPrint-PrintTimeGenius.git@70081671a24628aa23d9da28ff58b7b9ec8fa104
      Cloning https://github.com/eyal0/OctoPrint-PrintTimeGenius.git (to revision 70081671a24628aa23d9da28ff58b7b9ec8fa104) to ./pip-install-l7qr49d1/octoprint-printtimegenius_caa61677980a42b2b4f4efcc75219277
      Running command git clone -q https://github.com/eyal0/OctoPrint-PrintTimeGenius.git /tmp/pip-install-l7qr49d1/octoprint-printtimegenius_caa61677980a42b2b4f4efcc75219277
      Running command git rev-parse -q --verify 'sha^70081671a24628aa23d9da28ff58b7b9ec8fa104'
      Running command git fetch -q https://github.com/eyal0/OctoPrint-PrintTimeGenius.git 70081671a24628aa23d9da28ff58b7b9ec8fa104
      Running command git checkout -q 70081671a24628aa23d9da28ff58b7b9ec8fa104
      Resolved https://github.com/eyal0/OctoPrint-PrintTimeGenius.git to commit 70081671a24628aa23d9da28ff58b7b9ec8fa104
      Running command git submodule update --init --recursive -q
      git@github.com: Permission denied (publickey).
      fatal: Could not read from remote repository.

      Please make sure you have the correct access rights
      and the repository exists.
      fatal: clone of 'git@github.com:eyal0/Marlin.git' into submodule path '/tmp/pip-install-l7qr49d1/octoprint-printtimegenius_caa61677980a42b2b4f4efcc75219277/submodules/Marlin' failed
      Failed to clone 'submodules/Marlin'. Retry scheduled
      git@github.com: Permission denied (publickey).
      fatal: Could not read from remote repository.

      Please make sure you have the correct access rights
      and the repository exists.
      fatal: clone of 'git@github.com:eyal0/Marlin.git' into submodule path '/tmp/pip-install-l7qr49d1/octoprint-printtimegenius_caa61677980a42b2b4f4efcc75219277/submodules/Marlin' failed
      Failed to clone 'submodules/Marlin' a second time, aborting
    WARNING: Discarding git+https://github.com/eyal0/OctoPrint-PrintTimeGenius.git@70081671a24628aa23d9da28ff58b7b9ec8fa104. Command errored out with exit status 1: git submodule update --init --recursive -q Check the logs for full command output.

This is easily mitigated by using the https URLs for submodules. If you do not have an ssh key added to a user with appropriate permissions, you cannot use the `git@` scheme. This affects pretty much anyone except for you, as your user owns that fork?