### PR TITLE
Make percentage in M73 optional

### DIFF
--- a/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
@@ -84,7 +84,7 @@ def process_slic3r_print_time(gcode_line):
 def process_slic3r_print_time_remaining(gcode_line):
   """Match a Slic3r PE print time remaining estimate"""
   ret = dd()
-  m = re.match('\s*M73\s+P([0-9.]+)\s+R([0-9.]+)\s*', gcode_line)
+  m = re.match('\s*M73\s+(?:P([0-9.]+)\s+)?R([0-9.]+)\s*', gcode_line)
   if m:
     minutes_text = m.group(2)
     minutes_elapsed = float(minutes_text)


### PR DESCRIPTION
One of Cura's postprocessing plugin is capable of outputting M73 commands as well. However this plugin puts 2 separate lines for both percentage and time remaining like so:
```
M73 P55
M73 R43
```
Since this is perfectly valid gcode I have slightly altered the regular expression used to match these lines so the percentage parameter is now optional.