### PR TITLE
Fixing string sort to be integer sort

### DIFF
--- a/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
@@ -7,11 +7,11 @@ import sys
 from collections import defaultdict
 import argparse
 
-python_version_above_3_3 = [sys.version_info.major, sys.version_info.minor] > [3, 3]
+python_version_above_3_3 = sys.version_info > (3, 3)
 if python_version_above_3_3:
-	from collections import Mapping as collections_Mapping
+  from collections import Mapping as collections_Mapping
 else:
-	from collections.abc import Mapping as collections_Mapping
+  from collections.abc import Mapping as collections_Mapping
 
 dd = lambda: defaultdict(dd)
 

--- a/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_gcode_comments.py
@@ -6,10 +6,12 @@ import json
 import sys
 from collections import defaultdict
 import argparse
-if float('.'.join((str(sys.version_info.major), str(sys.version_info.minor)))) < 3.3:
-  from collections import Mapping as collections_Mapping
+
+python_version_above_3_3 = [sys.version_info.major, sys.version_info.minor] > [3, 3]
+if python_version_above_3_3:
+	from collections import Mapping as collections_Mapping
 else:
-  from collections.abc import Mapping as collections_Mapping
+	from collections.abc import Mapping as collections_Mapping
 
 dd = lambda: defaultdict(dd)
 


### PR DESCRIPTION
Since 3.10 = 3.1 and 3.1 < 3.3, this was breaking. I've fixed it and made it a bit more readable.