### PR TITLE
fix: fix uploading on OctoPrint 1.11+

### DIFF
--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -573,10 +573,10 @@ class PrintTimeGeniusPlugin(octoprint.plugin.SettingsPlugin,
     for dest in all_files.keys():
       self.unmark_all_pending(dest, all_files[dest])
 
-    # TODO: Remove the below after https://github.com/foosel/OctoPrint/pull/2723 is merged.
+    # TODO: https://github.com/foosel/OctoPrint/pull/2723 has been merged for almost 7 years, test if this monkey patch can be removed
     self._file_manager.original_add_file = self._file_manager.add_file
-    def new_add_file(destination, path, file_object, links=None, allow_overwrite=False, printer_profile=None, analysis=None, display=None):
-      return self._file_manager.original_add_file(destination, path, file_object, links, allow_overwrite, printer_profile, None, display)
+    def new_add_file(destination, path, file_object, links=None, allow_overwrite=False, printer_profile=None, analysis=None, display=None, *args, **kwargs):
+      return self._file_manager.original_add_file(destination, path, file_object, links=links, allow_overwrite=allow_overwrite, printer_profile=printer_profile, analysis=None, display=display, *args, **kwargs)
     self._file_manager.add_file = new_add_file
     # Work around for broken rc2
     if pkg_resources.parse_version(octoprint._version.get_versions()['version']) == pkg_resources.parse_version("1.3.9rc2"):


### PR DESCRIPTION
Extends `new_add_file`'s signature by `*args, **kwargs` to no longer cause errors on added parameters for this function.

Fixes #322 

Note: I found the comment above that monkey patched function quite amusing given that it said to remove the monkey patch after a specific PR was merged - said PR has been merged now for over 7 years. I thus changed the TODO to check if that patch can now be removed instead.

