### PR TITLE
Remove pkg_resources workaround for 1.3.9 rc2 version

### DIFF
--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -10,7 +10,6 @@ from octoprint.filemanager.analysis import AnalysisAborted
 from flask_babel import gettext
 import logging
 import bisect
-from pkg_resources import parse_version
 import sarge
 import json
 import shlex
@@ -310,12 +309,7 @@ class GeniusAnalysisQueue(GcodeAnalysisQueue):
       logger.info("Running: {}".format(command))
       results_err = ""
       try:
-        if parse_version(sarge.__version__) >= parse_version('0.1.5'):
-          # Because in version 0.1.5 the name was changed in sarge.
-          async_kwarg = 'async_'
-        else:
-          async_kwarg = 'async'
-        sarge_job = sarge.capture_both(command, **{async_kwarg: True})
+        sarge_job = sarge.capture_both(command, async_=True)
         # Wait for sarge to begin
         while not sarge_job.processes or not sarge_job.processes[0]:
           time.sleep(0.5)

--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -20,7 +20,6 @@ import sys
 import types
 import yaml
 import flask
-import pkg_resources
 import errno
 from threading import Timer
 from collections import defaultdict, abc
@@ -570,14 +569,6 @@ class PrintTimeGeniusPlugin(octoprint.plugin.SettingsPlugin,
     all_files = self._file_manager.list_files()
     for dest in all_files.keys():
       self.unmark_all_pending(dest, all_files[dest])
-
-    # Work around for broken rc2
-    if pkg_resources.parse_version(octoprint._version.get_versions()['version']) == pkg_resources.parse_version("1.3.9rc2"):
-      self._printer.old_on_comm = self._printer.on_comm_file_selected
-      def new_on_comm(self, *args, **kwargs):
-        self.old_on_comm(*args, **kwargs)
-        self._create_estimator()
-      self._printer.on_comm_file_selected = types.MethodType(new_on_comm, self._printer)
 
     # Get printer_config from printer_config.yaml
     printer_config_path = os.path.join(self.get_plugin_data_folder(),

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_PrintTimeGenius"
 plugin_name = "OctoPrint-PrintTimeGenius"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "2.4.1"
+plugin_version = "2.4.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -34,7 +34,7 @@ plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
 # For now, require the working release, which is only 1.3.9rc1.
-plugin_requires = ["OctoPrint>=1.3.9rc1", "psutil", "sarge"]
+plugin_requires = ["OctoPrint>=1.4.0", "psutil", "sarge"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
This resolves recent changes to setuptools removal of pkg_resources. https://github.com/eyal0/OctoPrint-PrintTimeGenius/issues/330