### PR TITLE
Fix crashes from inf/-inf in marlin-calc output and None filament values

### DIFF
--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -365,20 +365,23 @@ class GeniusAnalysisQueue(GcodeAnalysisQueue):
     # Before we potentially modify the result from analysis, save them.
     results.update({'analysisPending': False})
     try:
-      if not all(x in results
+      if not all(results.get(x) is not None
                  for x in ["progress",
                            "firstFilament",
                            "lastFilament"]):
         return results
       results["analysisPrintTime"] = results["estimatedPrintTime"]
+      first_interp = _interpolate_list(results["progress"], results["firstFilament"])
+      last_interp = _interpolate_list(results["progress"], results["lastFilament"])
+      if first_interp is None or last_interp is None:
+        logger.warning(
+            "Cannot compensate: firstFilament=%s lastFilament=%s are out of range",
+            results["firstFilament"], results["lastFilament"])
+        return results
       results["analysisFirstFilamentPrintTime"] = (
-          results["analysisPrintTime"] - _interpolate_list(
-              results["progress"],
-              results["firstFilament"])[1])
+          results["analysisPrintTime"] - first_interp[1])
       results["analysisLastFilamentPrintTime"] = (
-          results["analysisPrintTime"] - _interpolate_list(
-              results["progress"],
-              results["lastFilament"])[1])
+          results["analysisPrintTime"] - last_interp[1])
       self.compensate_analysis(results) # Adjust based on history
       logger.info("Compensated result: {}".format(results))
     except Exception as e:

--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -343,6 +343,7 @@ class GeniusAnalysisQueue(GcodeAnalysisQueue):
         bedZ = self._plugin._settings.get(["bedZ"])
         if ("printingArea" in new_results and
             "minZ" in new_results["printingArea"] and
+            new_results["printingArea"]["minZ"] is not None and
             bedZ is not None):
           old_minZ = new_results["printingArea"]["minZ"]
           new_minZ = min(bedZ, old_minZ)

--- a/octoprint_PrintTimeGenius/analyzers/analyze_progress.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_progress.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import subprocess
 import sys
 import json
+import re
 import os
 import platform
 
@@ -63,6 +64,8 @@ def main():
         last_row = [filepos, time]
     elif line.startswith(b"Analysis:"):
       line = line[len("Analysis:"):]
+      line = re.sub(rb':\s*-?inf\b', b': null', line, flags=re.IGNORECASE)
+      line = re.sub(rb':\s*nan\b', b': null', line, flags=re.IGNORECASE)
       result.update(json.loads(line))
   if last_row:
     progress.append(last_row)


### PR DESCRIPTION
  ## Summary

  - **`analyze_progress.py`**: `marlin-calc` outputs `inf`/`-inf` for axes
    with no movement. Python's `json.loads` rejects these non-standard JSON
    values. Fix: sanitize `Analysis:` lines with regex to replace
    `inf`/`-inf`/`nan` with `null` before parsing.

  - **`__init__.py` (bedZ adjustment)**: Consequence of the above — `minZ`
    is now `null` instead of `-inf`, causing `min(bedZ, None)` to crash.
    Fix: add `None` guard on `minZ` before the comparison.

  - **`__init__.py` (compensation)**: `firstFilament` is `null` when a
    gcode file has no extrusion moves. The key-existence check passed even
    with `None` values, leading to a `TypeError` in `_interpolate_list`.
    Fix: check `results.get(x) is not None` instead, and guard against
    `_interpolate_list` returning `None` for out-of-range points.