### PR TITLE
Fix crashes from inf/-inf in marlin-calc output and None filament values

### DIFF
--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -117,10 +117,12 @@ class GeniusEstimator(PrintTimeEstimator):
       return None # We're not even in range yet.
     # We advanced to a new index, let's make new estimates.
     if (not "firstFilamentPrintTime" in self._current_history and
+        self._metadata["analysis"]["firstFilament"] is not None and
         progress > self._metadata["analysis"]["firstFilament"]):
       self._current_history["firstFilamentPrintTime"] = printTime
     if (not "lastFilamentPrintTime" in self._current_history or
-        progress <= self._metadata["analysis"]["lastFilament"]):
+        (self._metadata["analysis"]["lastFilament"] is None or
+         progress <= self._metadata["analysis"]["lastFilament"])):
       self._current_history["lastFilamentPrintTime"] = printTime
     interpolation = _interpolate(progress, self._progress[self._current_progress_index], self._progress[self._current_progress_index+1])
     # This is our best guess for the total print time.

--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -343,6 +343,7 @@ class GeniusAnalysisQueue(GcodeAnalysisQueue):
         bedZ = self._plugin._settings.get(["bedZ"])
         if ("printingArea" in new_results and
             "minZ" in new_results["printingArea"] and
+            new_results["printingArea"]["minZ"] is not None and
             bedZ is not None):
           old_minZ = new_results["printingArea"]["minZ"]
           new_minZ = min(bedZ, old_minZ)
@@ -365,20 +366,23 @@ class GeniusAnalysisQueue(GcodeAnalysisQueue):
     # Before we potentially modify the result from analysis, save them.
     results.update({'analysisPending': False})
     try:
-      if not all(x in results
+      if not all(results.get(x) is not None
                  for x in ["progress",
                            "firstFilament",
                            "lastFilament"]):
         return results
       results["analysisPrintTime"] = results["estimatedPrintTime"]
+      first_interp = _interpolate_list(results["progress"], results["firstFilament"])
+      last_interp = _interpolate_list(results["progress"], results["lastFilament"])
+      if first_interp is None or last_interp is None:
+        logger.warning(
+            "Cannot compensate: firstFilament=%s lastFilament=%s are out of range",
+            results["firstFilament"], results["lastFilament"])
+        return results
       results["analysisFirstFilamentPrintTime"] = (
-          results["analysisPrintTime"] - _interpolate_list(
-              results["progress"],
-              results["firstFilament"])[1])
+          results["analysisPrintTime"] - first_interp[1])
       results["analysisLastFilamentPrintTime"] = (
-          results["analysisPrintTime"] - _interpolate_list(
-              results["progress"],
-              results["lastFilament"])[1])
+          results["analysisPrintTime"] - last_interp[1])
       self.compensate_analysis(results) # Adjust based on history
       logger.info("Compensated result: {}".format(results))
     except Exception as e:

--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -353,6 +353,15 @@ class GeniusAnalysisQueue(GcodeAnalysisQueue):
             if ("dimensions" in new_results and
                 "height" in new_results["dimensions"]):
               new_results["dimensions"]["height"] += old_minZ - new_minZ
+        # Don't overwrite existing non-null values with null from the analyzer.
+        # The ARM binary can output inf→null for printingArea/dimensions while
+        # the built-in OctoPrint analysis may have valid values.
+        for key in ("printingArea", "dimensions"):
+          if key in new_results and isinstance(new_results[key], dict):
+            new_results[key] = {k: v for k, v in new_results[key].items()
+                                if v is not None}
+            if not new_results[key]:
+              del new_results[key]
         results.update(new_results)
         logger.info("Merged result: {}".format(results))
       except AnalysisAborted as e:

--- a/octoprint_PrintTimeGenius/analyzers/analyze_progress.py
+++ b/octoprint_PrintTimeGenius/analyzers/analyze_progress.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import subprocess
 import sys
 import json
+import re
 import os
 import platform
 
@@ -63,6 +64,8 @@ def main():
         last_row = [filepos, time]
     elif line.startswith(b"Analysis:"):
       line = line[len("Analysis:"):]
+      line = re.sub(rb':\s*-?inf\b', b': null', line, flags=re.IGNORECASE)
+      line = re.sub(rb':\s*nan\b', b': null', line, flags=re.IGNORECASE)
       result.update(json.loads(line))
   if last_row:
     progress.append(last_row)


### PR DESCRIPTION
  ## Summary

  - **`analyze_progress.py`**: `marlin-calc` outputs `inf`/`-inf` for axes
    with no movement. Python's `json.loads` rejects these non-standard JSON
    values. Fix: sanitize `Analysis:` lines with regex to replace
    `inf`/`-inf`/`nan` with `null` before parsing.

  - **`__init__.py` (bedZ adjustment)**: Consequence of the above — `minZ`
    is now `null` instead of `-inf`, causing `min(bedZ, None)` to crash.
    Fix: add `None` guard on `minZ` before the comparison.

  - **`__init__.py` (compensation)**: `firstFilament` is `null` when a
    gcode file has no extrusion moves. The key-existence check passed even
    with `None` values, leading to a `TypeError` in `_interpolate_list`.
    Fix: check `results.get(x) is not None` instead, and guard against
    `_interpolate_list` returning `None` for out-of-range points.
    
  - Don't overwrite valid printingArea/dimensions from built-in analysis with null values from the custom
  analyzer (ARM binary produces inf → null for some files)
  
  - Fix TypeError in time estimator when firstFilament/lastFilament is null

  During printing, _genius_estimate compared progress > metadata["firstFilament"] — but when the ARM binary
  produced inf values (sanitized to null), this comparison raised TypeError: '>' not supported between
  'float' and 'NoneType', silently falling back to OctoPrint's built-in estimator for the entire print.

  - firstFilament is None → skip recording firstFilamentPrintTime
  - lastFilament is None → keep updating lastFilamentPrintTime (safe fallback)
