### PR TITLE
Fix KeyError on missing firstFilament/lastFilament (silent fallback to linear estimates)

### DIFF
--- a/octoprint_PrintTimeGenius/__init__.py
+++ b/octoprint_PrintTimeGenius/__init__.py
@@ -118,12 +118,12 @@ class GeniusEstimator(PrintTimeEstimator):
       return None # We're not even in range yet.
     # We advanced to a new index, let's make new estimates.
     if (not "firstFilamentPrintTime" in self._current_history and
-        self._metadata["analysis"]["firstFilament"] is not None and
-        progress > self._metadata["analysis"]["firstFilament"]):
+        self._metadata["analysis"].get("firstFilament") is not None and
+        progress > self._metadata["analysis"].get("firstFilament")):
       self._current_history["firstFilamentPrintTime"] = printTime
     if (not "lastFilamentPrintTime" in self._current_history or
-        (self._metadata["analysis"]["lastFilament"] is None or
-         progress <= self._metadata["analysis"]["lastFilament"])):
+        (self._metadata["analysis"].get("lastFilament") is None or
+         progress <= self._metadata["analysis"].get("lastFilament"))):
       self._current_history["lastFilamentPrintTime"] = printTime
     interpolation = _interpolate(progress, self._progress[self._current_progress_index], self._progress[self._current_progress_index+1])
     # This is our best guess for the total print time.


### PR DESCRIPTION
### Problem
`GeniusEstimator._genius_estimate()` reads `self._metadata["analysis"]["firstFilament"]` and `["lastFilament"]` with direct indexing. Those keys are only written by the **marlin-calc** analyzer (`analyze_progress.py`). When marlin-calc is disabled and estimates come from a gcode-comment analyzer — e.g. the Slic3r-PE/PrusaSlicer **M73** analyzer (`analyze_gcode_comments.py`), which writes `firstFilament` but **never** `lastFilament` — the key is absent and the lookup raises `KeyError`.

`estimate()` catches this (`"Failed to estimate, ignoring"`) and silently falls back to OctoPrint's built-in **linear** estimator for the rest of the print. The very first call is unaffected (progress is forced to `0` and returns earlier), so the analysis and logs look perfect while the live *time-left* is wrong. This likely explains symptom reports such as #186 ("Logs show perfect estimations, OctoPrint time-left never gets updated").

### Reproduce
1. Enable only the M73 analyzer ("Use Slic3r PE M73 time remaining"); disable marlin-calc.
2. Print a PrusaSlicer file with `M73` comments.
3. Time-left origin is `linear` after the first update; `_genius_estimate` raises `KeyError: 'lastFilament'` at every `progress > 0`.

### Fix
Use `dict.get()` so a missing key is treated like a `None` value, which the surrounding logic already handles. Only the cross-print learning history is affected when the keys are absent; the returned estimate (interpolated progress table) is unchanged.

### Disclosure
The root-cause investigation and this patch were produced with AI assistance (Anthropic's Claude, via Claude Code) and reviewed by me before submission. The commit also carries a `Co-Authored-By: Claude` trailer.
